### PR TITLE
Fix build error when using CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project(gotcha VERSION 1.0.4 LANGUAGES C CXX)
 


### PR DESCRIPTION
CMake 4.0 removes support for CMake < 3.5